### PR TITLE
Pequeño cambio en la implementación de la carga de datos

### DIFF
--- a/claqueta_tfg/src/main/kotlin/com/app/claquetaTfg/database/ClassesPersistenceLayer.kt
+++ b/claqueta_tfg/src/main/kotlin/com/app/claquetaTfg/database/ClassesPersistenceLayer.kt
@@ -1,5 +1,7 @@
 package com.app.claquetaTfg.database
 
+import com.app.claquetaTfg.domain.Film
+import com.app.claquetaTfg.domain.Review
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
@@ -49,10 +51,31 @@ class DatabasePersistenceLayer<T : Any>(
         }
     }
 
-    override fun loadData(): List<Any> {
+    override fun loadData(): Any {
         val content = file.readText()
-		if(content.isEmpty()) return emptyList()
-        return jsonPrettyFormat.decodeFromString(ListSerializer(serializer), content)
+        if (content.isEmpty()) return hashMapOf<Any, Any>()
+        when (classType) {
+            Film::class -> {
+                val list = jsonPrettyFormat.decodeFromString(ListSerializer(serializer), content)
+                val map: HashMap<String, Film> = hashMapOf()
+                for (film: Film in list as List<Film>) {
+                    map.getOrPut(film.id) { film }
+                }
+                return map
+            }
+
+            Review::class -> {
+                val list = jsonPrettyFormat.decodeFromString(ListSerializer(serializer), content)
+                val map: HashMap<String, HashSet<Review>> = hashMapOf()
+                for (review: Review in list as List<Review>) {
+                    map.getOrPut(review.filmId) { HashSet() }.add(review)
+                    map.getOrPut(review.userName) { HashSet() }.add(review)
+                }
+                return map
+            }
+
+            else -> return hashMapOf<Any, Any>()
+        }
     }
 }
 

--- a/claqueta_tfg/src/test/kotlin/com/app/claquetaTfg/database/DatabasePersistenceLayerTest.kt
+++ b/claqueta_tfg/src/test/kotlin/com/app/claquetaTfg/database/DatabasePersistenceLayerTest.kt
@@ -5,6 +5,7 @@ import com.app.claquetaTfg.domain.Film
 import com.app.claquetaTfg.domain.Review
 import com.app.claquetaTfg.util.Constants.resourcesExamplePath
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.decodeFromString
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.File

--- a/claqueta_tfg/src/test/kotlin/com/app/claquetaTfg/database/DatabasePersistenceLayerTest.kt
+++ b/claqueta_tfg/src/test/kotlin/com/app/claquetaTfg/database/DatabasePersistenceLayerTest.kt
@@ -4,7 +4,6 @@ package com.app.claquetaTfg.database
 import com.app.claquetaTfg.domain.Film
 import com.app.claquetaTfg.domain.Review
 import com.app.claquetaTfg.util.Constants.resourcesExamplePath
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -49,6 +48,7 @@ class DatabasePersistenceLayerTest {
 
     @Test
     fun `When I want to save only one film`() {
+
         val uniqFilm = Film(
             exampleFilms[1].id,
             exampleFilms[1].title,
@@ -60,14 +60,14 @@ class DatabasePersistenceLayerTest {
         )
 
         //When
-        val loadListBefore = dataManagerFilms.loadData() as List<Film>
+        val loadDataBefore = dataManagerFilms.loadData() as HashMap<*, *>
         dataManagerFilms.saveData(uniqFilm)
-        val loadListAfter = dataManagerFilms.loadData() as List<Film>
-        val amountAdd = loadListAfter.size-loadListBefore.size
+        val loadDataAfter = dataManagerFilms.loadData() as HashMap<*, *>
+        val amountAdd = loadDataAfter.size-loadDataBefore.size
         //Then
-        assertTrue(loadListAfter.isNotEmpty())
-        assertFalse(loadListAfter.contains<Film?>(null))
-        assertEquals(loadListAfter.size,loadListBefore.size+amountAdd)
+        assertTrue(loadDataAfter.isNotEmpty())
+        assertFalse(loadDataAfter.values.any{it==null})
+        assertEquals(loadDataAfter.size,loadDataBefore.size+amountAdd)
     }
 
     @Test
@@ -88,14 +88,15 @@ class DatabasePersistenceLayerTest {
         }
 
         //When
-        val loadListBefore = dataManagerFilms.loadData() as List<Film>
+        val loadDataBefore = dataManagerFilms.loadData() as HashMap<*, *>
         dataManagerFilms.saveData(filmList)
-        val loadListAfter = dataManagerFilms.loadData() as List<Film>
-        val amountAdd = loadListAfter.size-loadListBefore.size
+        val loadDataAfter = dataManagerFilms.loadData() as HashMap<*, *>
+        val amountAdd = loadDataAfter.size-loadDataBefore.size
+        println(loadDataBefore)
         //Then
-        assertTrue(loadListAfter.isNotEmpty())
-        assertFalse(loadListAfter.contains<Film?>(null))
-        assertEquals(loadListAfter.size , loadListBefore.size+amountAdd)
+        assertTrue(loadDataAfter.isNotEmpty())
+        assertFalse(loadDataAfter.values.any{it==null})
+        assertEquals(loadDataAfter.size , loadDataBefore.size+amountAdd)
     }
 
     @Test
@@ -110,14 +111,15 @@ class DatabasePersistenceLayerTest {
         )
 
         //When
-        val loadListBefore = dataManagerReviews.loadData() as List<Review>
+        val loadDataBefore = dataManagerReviews.loadData() as HashMap<*, *>
         dataManagerReviews.saveData(uniqReview)
-        val loadListAfter = dataManagerReviews.loadData() as List<Review>
-        val amountAdd = loadListAfter.size-loadListBefore.size
+        val loadDataAfter = dataManagerReviews.loadData() as HashMap<*, *>
+        val amountAdd = loadDataAfter.size-loadDataBefore.size
         //Then
-        assertTrue(loadListAfter.isNotEmpty())
-        assertFalse(loadListAfter.contains<Review?>(null))
-        assertEquals(loadListAfter.size , loadListBefore.size+amountAdd)
+        println(loadDataAfter)
+        assertTrue(loadDataAfter.isNotEmpty())
+        assertFalse(loadDataAfter.values.any{it==null})
+        assertEquals(loadDataAfter.size , loadDataBefore.size+amountAdd)
     }
 
     @Test
@@ -136,14 +138,15 @@ class DatabasePersistenceLayerTest {
         }
 
         //When
-        val loadListBefore = dataManagerReviews.loadData() as List<Review>
+        val loadDataBefore = dataManagerReviews.loadData() as HashMap<*, *>
         dataManagerReviews.saveData(reviewList)
-        val loadListAfter = dataManagerReviews.loadData() as List<Review>
-        val amountAdd = loadListAfter.size-loadListBefore.size
+        val loadDataAfter = dataManagerReviews.loadData() as HashMap<*, *>
+        val amountAdd = loadDataAfter.size-loadDataBefore.size
         //Then
-        assertTrue(loadListAfter.isNotEmpty())
-        assertFalse(loadListAfter.contains<Review?>(null))
-        assertEquals(loadListAfter.size , loadListBefore.size+amountAdd)
+        println(loadDataAfter)
+        assertTrue(loadDataAfter.isNotEmpty())
+        assertFalse(loadDataAfter.values.any{it==null})
+        assertEquals(loadDataAfter.size , loadDataBefore.size+amountAdd)
     }
 }
 

--- a/doc/secciones/06_implementacion.tex
+++ b/doc/secciones/06_implementacion.tex
@@ -553,13 +553,18 @@ solo habría que añadir dicho mecanismo concreto, pero el resto de código dond
 Para la implementación de la abstracción se ha recurrido a crear una interfaz llamada 
 \begin{otherlanguage} {english}``\textit{\textbf{PersistenceLayer}}''\end{otherlanguage}, 
 con dos operaciones, la operación de guardar datos y la de cargar dichos datos, estas se han creado usando 
-genéricos \cite{genericsBook}, ya que gracias a ellos se puede dar cualquier tipo de implementación que se quiera de 
-la capa de persistencia mientras herede de la interfaz, ya que no especifica el uso de tipos para los parámetros o 
-para los datos que se retornan. Por ende haciendo uso de la interfaz se ha llevado a cabo la implementación de una 
-capa de persistencia que guarda y recupera datos de archivos Json, esta se encarga de sobrescribir los métodos de la
-interfaz para guardar y cargar datos, además puede operar con objetos individuales o listas de objetos. Por otra 
-parte, se ha creado una clase para inyectar cualquier implementación, siguiendo las mejores prácticas para cumplir 
-con el principio de inversión de dependencias, además de asegurar que no se viola el principio de sustitución de 
-Liskov. 
+genéricos \cite{genericsBook}, ya que gracias a ellos se puede dar cualquier tipo de implementación que se quiera 
+de la capa de persistencia mientras herede de la interfaz, ya que no especifica el uso de tipos para los parámetros 
+o para los datos que se retornan. Por ende haciendo uso de la interfaz se ha llevado a cabo la implementación de 
+una capa de persistencia que guarda y recupera datos de archivos Json, esta se encarga de sobrescribir los métodos 
+de la interfaz para guardar y cargar datos, además puede operar con objetos individuales o listas de objetos. La 
+carga de datos de esta implementación se realiza a razón de las estructuras de la clase 
+\begin{otherlanguage} {english}``\textit{\textbf{manager}}''\end{otherlanguage} 
+vista en el modelo de dominio, en este caso devuelve los 
+datos en mapas, estructuras que se definen y explican en el hito anterior.
+
+Por otra parte, se ha creado una clase para inyectar cualquier implementación, siguiendo las mejores prácticas para 
+cumplir con el principio de inversión de dependencias, además de asegurar que no se viola el principio de 
+sustitución de Liskov.  
 
 Se concederá la validación a este hito si pasa los test unitarios para guardar y cargar distintos tipos de datos.   


### PR DESCRIPTION
Cambio en la implementación de la carga de datos, ya que se devolvían listas de objetos, más ClaquetaManager trabaja con mapas cuando se trata de las películas y de las reseñas por ende era necesario cambiar y devolver los datos siguiendo la estructura necesaria porque si no acarrearía problemas más adelante

(-closes #143)